### PR TITLE
Fix syntaxe error

### DIFF
--- a/client/ui/services/auth.context.tsx
+++ b/client/ui/services/auth.context.tsx
@@ -16,7 +16,7 @@ class AuthProvider extends Component {
 		// this causes the user info to only be retrieved when the component is
 		// mounted, so there's a slight delay with the info showing
 		this.setState({
-			isLoggedIn: JSON.parse(localStorage.getItem('isLoggedIn') || ''),
+			isLoggedIn: JSON.parse(localStorage.getItem('isLoggedIn')),
 			email: localStorage.getItem('email')
 		});
 	}


### PR DESCRIPTION
isLoggedIn: JSON.parse(localStorage.getItem('isLoggedIn') || '') is giving me the following error:
SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data